### PR TITLE
Support terrraform 0.12 and later

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Send SMS messages to a group via AWS SNS
 
+## Terraform versions
+
+For Terraform versions >= 0.12 use versions tagged 0.5.0 or later, for
+Terraform 0.11 use 0.4.0.
+
 ## Quickstart
 
 Create a `main.tf` file with the following contents:

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,10 @@
 locals {
-  display_name = "${coalesce("${var.topic_display_name}", "${var.topic_name}")}"
+  display_name = coalesce(var.topic_display_name, var.topic_name)
 }
 
 data "aws_iam_policy_document" "assume_role" {
   statement {
-    actions    = ["sts:AssumeRole"]
+    actions = ["sts:AssumeRole"]
 
     principals {
       type        = "Service"
@@ -16,12 +16,12 @@ data "aws_iam_policy_document" "assume_role" {
 data "aws_iam_policy_document" "delivery_status_role_inline_policy" {
   statement {
     resources = ["*"]
-    actions   = [
+    actions = [
       "logs:CreateLogGroup",
       "logs:CreateLogStream",
       "logs:PutLogEvents",
       "logs:PutMetricFilter",
-      "logs:PutRetentionPolicy"
+      "logs:PutRetentionPolicy",
     ]
   }
 }
@@ -43,7 +43,7 @@ data "aws_iam_policy_document" "delivery_status_bucket_policy" {
   statement {
     sid       = "AllowGetBucketLocation"
     actions   = ["s3:GetBucketLocation"]
-    resources = ["${aws_s3_bucket.delivery_status_bucket.arn}"]
+    resources = [aws_s3_bucket.delivery_status_bucket.arn]
 
     principals {
       type        = "Service"
@@ -55,31 +55,31 @@ data "aws_iam_policy_document" "delivery_status_bucket_policy" {
 data "aws_iam_policy_document" "publish" {
   statement {
     actions   = ["sns:Publish"]
-    resources = ["${aws_sns_topic.topic.arn}"]
+    resources = [aws_sns_topic.topic.arn]
   }
 }
 
 resource "aws_iam_policy" "publish" {
-  name        = "${var.policy_name}"
-  path        = "${var.policy_path}"
+  name        = var.policy_name
+  path        = var.policy_path
   description = "Allow publishing to Group SMS SNS Topic"
-  policy      = "${data.aws_iam_policy_document.publish.json}"
+  policy      = data.aws_iam_policy_document.publish.json
 }
 
 resource "aws_iam_role" "delivery_status_role" {
   description        = "Allow AWS to publish SMS delivery status logs"
-  name               = "${var.role_name}"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  name               = var.role_name
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
 resource "aws_iam_role_policy" "delivery_status_role_inline_policy" {
   name   = "${aws_iam_role.delivery_status_role.name}InlinePolicy"
-  role   = "${aws_iam_role.delivery_status_role.id}"
-  policy = "${data.aws_iam_policy_document.delivery_status_role_inline_policy.json}"
+  role   = aws_iam_role.delivery_status_role.id
+  policy = data.aws_iam_policy_document.delivery_status_role_inline_policy.json
 }
 
 resource "aws_s3_bucket" "delivery_status_bucket" {
-  bucket = "${var.usage_report_s3_bucket}"
+  bucket = var.usage_report_s3_bucket
   acl    = "private"
 
   server_side_encryption_configuration {
@@ -92,27 +92,28 @@ resource "aws_s3_bucket" "delivery_status_bucket" {
 }
 
 resource "aws_s3_bucket_policy" "delivery_status_bucket_policy" {
-  bucket = "${aws_s3_bucket.delivery_status_bucket.bucket}"
-  policy = "${data.aws_iam_policy_document.delivery_status_bucket_policy.json}"
+  bucket = aws_s3_bucket.delivery_status_bucket.bucket
+  policy = data.aws_iam_policy_document.delivery_status_bucket_policy.json
 }
 
 resource "aws_sns_sms_preferences" "sms_preferences" {
-  default_sender_id                     = "${var.default_sender_id}"
-  default_sms_type                      = "${var.default_sms_type}"
-  delivery_status_iam_role_arn          = "${aws_iam_role.delivery_status_role.arn}"
-  delivery_status_success_sampling_rate = "${var.delivery_status_success_sampling_rate}"
-  monthly_spend_limit                   = "${var.monthly_spend_limit}"
-  usage_report_s3_bucket                = "${aws_s3_bucket.delivery_status_bucket.bucket}"
+  default_sender_id                     = var.default_sender_id
+  default_sms_type                      = var.default_sms_type
+  delivery_status_iam_role_arn          = aws_iam_role.delivery_status_role.arn
+  delivery_status_success_sampling_rate = var.delivery_status_success_sampling_rate
+  monthly_spend_limit                   = var.monthly_spend_limit
+  usage_report_s3_bucket                = aws_s3_bucket.delivery_status_bucket.bucket
 }
 
 resource "aws_sns_topic" "topic" {
-  display_name = "${local.display_name}"
-  name         = "${var.topic_name}"
+  display_name = local.display_name
+  name         = var.topic_name
 }
 
 resource "aws_sns_topic_subscription" "subscription" {
-  count     = "${length("${var.subscriptions}")}"
-  topic_arn = "${aws_sns_topic.topic.arn}"
+  count     = length(var.subscriptions)
+  topic_arn = aws_sns_topic.topic.arn
   protocol  = "sms"
-  endpoint  = "${element("${var.subscriptions}", count.index)}"
+  endpoint  = element(var.subscriptions, count.index)
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,14 +1,15 @@
 output "policy_arn" {
   description = "ARN of policy to publish to SNS Topic."
-  value       = "${aws_iam_policy.publish.arn}"
+  value       = aws_iam_policy.publish.arn
 }
 
 output "topic_arn" {
   description = "AWS Topic ARN."
-  value       = "${aws_sns_topic.topic.arn}"
+  value       = aws_sns_topic.topic.arn
 }
 
 output "topic_subscriptions" {
   description = "Subscriptions to SNS Topic."
-  value       = "${aws_sns_topic_subscription.subscription.*.endpoint}"
+  value       = aws_sns_topic_subscription.subscription.*.endpoint
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -1,58 +1,70 @@
 variable "default_sender_id" {
   description = "A custom ID, such as your business brand, displayed as the sender on the receiving device. Support for sender IDs varies by country."
+  type        = string
   default     = ""
 }
 
 variable "default_sms_type" {
   description = "Promotional messages are noncritical, such as marketing messages. Transactional messages are delivered with higher reliability to support customer transactions, such as one-time passcodes."
+  type        = string
   default     = "Promotional"
 }
 
 variable "delivery_status_iam_role_arn" {
   description = "The IAM role that allows Amazon SNS to write logs for SMS deliveries in CloudWatch Logs."
+  type        = string
   default     = ""
 }
 
 variable "delivery_status_success_sampling_rate" {
   description = "Default percentage of success to sample."
+  type        = number
   default     = ""
 }
 
 variable "monthly_spend_limit" {
   description = "The maximum amount to spend on SMS messages each month. If you send a message that exceeds your limit, Amazon SNS stops sending messages within minutes."
+  type        = number
   default     = 1
 }
 
 variable "policy_name" {
   description = "Name of policy to publish to Group SMS topic."
+  type        = string
   default     = "group-sms-publish"
 }
 
 variable "policy_path" {
   description = "Path of policy to publish to Group SMS topic"
+  type        = string
   default     = "/"
 }
 
 variable "role_name" {
   description = "The IAM role that allows Amazon SNS to write logs for SMS deliveries in CloudWatch Logs."
+  type        = string
   default     = "SNSSuccessFeedback"
 }
 
 variable "subscriptions" {
   description = "List of telephone numbers to subscribe to SNS."
-  type        = "list"
+  type        = list(string)
   default     = []
 }
 
 variable "topic_display_name" {
   description = "Display name of the AWS SNS topic."
+  type        = string
   default     = ""
 }
 
 variable "topic_name" {
   description = "Name of the AWS SNS topic."
+  type        = string
 }
 
 variable "usage_report_s3_bucket" {
   description = "The Amazon S3 bucket to receive daily SMS usage reports. The bucket policy must grant write access to Amazon SNS."
+  type        = string
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -19,7 +19,7 @@ variable "delivery_status_iam_role_arn" {
 variable "delivery_status_success_sampling_rate" {
   description = "Default percentage of success to sample."
   type        = number
-  default     = ""
+  default     = 0
 }
 
 variable "monthly_spend_limit" {


### PR DESCRIPTION
Hi, this PR introduces support for terraform 0.12 and newer, mostly syntax changes but also some explicit variable typing. It also presumptuously assumes a bump in the version tag as it's a breaking change.